### PR TITLE
Added support to control multiple fans independently

### DIFF
--- a/source/system-autofan/FanSettings.page
+++ b/source/system-autofan/FanSettings.page
@@ -13,6 +13,8 @@ Icon="dynamix.system.autofan.png"
  * all copies or substantial portions of the Software.
  *
  * Plugin development contribution by gfjardim
+ * Version log:
+ * Version 1.6   Modified by InfinityMod - added multifan support
  */
 ?>
 <?
@@ -21,6 +23,7 @@ $cfg    = parse_plugin_cfg($plugin);
 $sName  = "autofan";
 $fName  = "$docroot/plugins/$plugin/scripts/$sName";
 $width  = strstr('gray,azure',$display['theme']) ? 305:300;
+$fan_id = 1;
 
 function temp_val($val) {
   global $display;
@@ -95,14 +98,39 @@ function tempVal(form) {
   item.value = exclude;
   item.selected = true;
 }
+
+function getSettings(fan_id){
+    $.get('/plugins/<?=$plugin;?>/include/SystemFan.php',{op:'settings',fan_id:fan_id},function(txt) {
+        data = JSON.parse(txt);
+        Object.keys(data).forEach(key => {
+            var value = data[key];
+            if(key == "service")
+            {
+                $("select[name="+ key +"]")[0].selectedIndex = parseInt(value);
+            }else{
+                $("input[name="+ key +"]").val(value);
+            }
+        });
+        
+        $(document).ready(function(){
+            file_el =  $('input[name="#file"]');
+            file_el.attr("value", file_el.attr("file").replace(".cfg", "." + fan_id.toString() + ".cfg"));
+        })
+    });
+}
+
+
 $(function() {
   showStatus('<?=$sName?>');
   $('#s1').dropdownchecklist({emptyText:'None', width:<?=$width?>, explicitClose:'...close'});
 });
+
+getSettings(0);
+
 </script>
 
 <form markdown="1" method="POST" action="/update.php" target="progressFrame" onsubmit="tempVal(this)">
-<input type="hidden" name="#file" value="<?=$plugin?>/<?=$plugin?>.cfg">
+<input type="hidden" name="#file" file="<?=$plugin?>/<?=$plugin?>.cfg" value="<?=$plugin?>/<?=$plugin?>.cfg">
 <input type="hidden" name="#include" value="plugins/<?=$plugin?>/include/update.autofan.php">
 <input type="hidden" name="#prefix" value="controller=c&fan=f&pwm=l&low=t&high=T&interval=m&exclude=e">
 <span class="bitstream" style="float:right;margin-right:12px"><?=exec("$fName -V")?></span>
@@ -114,7 +142,7 @@ Fan control function:
   </select>
 
 PWM controller:
-: <select name="controller" size="1">
+: <select name="controller" size="1" onChange="getSettings(this.selectedIndex)">
   <?=mk_option($cfg['controller'], "", "None")?>
   <?foreach (list_pwm() as $pwm):?>
   <?=mk_option($cfg['controller'], $pwm['sensor'], "{$pwm['chip']} - {$pwm['name']}")?>

--- a/source/system-autofan/include/SystemFan.php
+++ b/source/system-autofan/include/SystemFan.php
@@ -9,6 +9,8 @@
  * all copies or substantial portions of the Software.
  *
  * Plugin development contribution by gfjardim
+ * Version log:
+ * Version 1.6   Modified by InfinityMod - added multifan support
  */
 ?>
 <?
@@ -87,5 +89,30 @@ if (is_file( $_GET['pwm']) && is_file( $_GET['fan'])) {
   file_put_contents($pwm."_enable", $default_method);
   exec("$autofan start >/dev/null");
 }
+break;
+case 'settings':
+   $fan_id = $_GET['fan_id'];
+   $plugin="dynamix.system.autofan";
+   $settings_root = "/boot/config/plugins/$plugin";
+   $docroot = $docroot ?: $_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp';
+   $std_settings = "$docroot/plugins/$plugin/default.cfg";
+   $settings = "$settings_root/$plugin.$fan_id.cfg";
+
+   if(!file_exists ($settings)){
+    $settings = $std_settings;
+   }
+   
+   $file_handle = fopen($settings, "rb");
+   $response = [];
+   while (!feof($file_handle) ) {
+    $line_of_text = fgets($file_handle);
+    $parts = explode('=', $line_of_text);
+    if ($parts[0] != ""){
+        $response[$parts[0]] = substr(substr($parts[1], 1), 0, -2);
+    }
+   }
+   fclose($file_handle);
+   echo json_encode($response);   
 break;}
+
 ?>

--- a/source/system-autofan/scripts/autofan
+++ b/source/system-autofan/scripts/autofan
@@ -22,6 +22,8 @@
 #                                    - celsius/fahrenheit conversion
 # Version 1.5   Modified by Bergware - added nvme devices temperature reading (contributed by syntactic-salt)
 #                                    - added exclude disks from temperature reading (contributed by andreiio)
+# Version 1.6   Modified by InfinityMod - added mulifan support
+#                                       - added fan spin up/down offset 
 #=======================================================================================
 # Dependencies: grep,awk,smartctl,hdparm
 #=======================================================================================
@@ -59,7 +61,9 @@ TEMP_HIGH=45   # Anything this number and above - fan is *full*
 # what numbers you want to use for your fan pwm settings. Should not need to
 # change the OFF variable, only the LOW and maybe also HIGH to what you desire.
 # Any real number between 0 and 255.
-PWM_OFF=30     # Off Value (note: many PWM fans will not turn off)
+PWM_OFF_OFFSET=30     # Offset on turning off PWM = (PWM_LOW - PWM_OFF_OFFSET)
+PWM_ON_OFFSET=30     # Offset on turning on PWM = (PWM_CALCULATED + PWM_ON_OFFSET)
+PWM_OFF=0      # Off Value (note: many PWM fans will not turn off)
 PWM_LOW=35     # Value to make your fan go slow
 PWM_HIGH=255   # Value to make your fan go fast
 
@@ -84,6 +88,9 @@ while getopts "t:T:m:c:f:l:qhVe:" opt; do
    \?) usage >&2 ; exit 0 ;;
   esac
 done
+
+#PID_NAME
+PID_NAME="autofan_${PWM_CONTROLLER##*/}_${PWM_FAN##*/}"
 
 show_values() {
   echo TEMP_LOW=$TEMP_LOW
@@ -120,7 +127,7 @@ if [[ ! -z $cc ]]; then
 fi
 
 # Lockfile processing
-lockfile="/var/run/${program_name}.pid"
+lockfile="/var/run/${PID_NAME}.pid"
 if [[ -f $lockfile ]]; then
   # The file exists so read the PID
   # to see if it is still running
@@ -228,6 +235,10 @@ function_calc_new_fan_speed() {
       ADJUSTED_FAN_SPEED=$PWM_HIGH
       ADJUSTED_PERCENT_SPEED=100
       ADJUSTED_OUTPUT="FULL"
+    elif [ "$ADJUSTED_OUTPUT" = "OFF" ]; then
+      ADJUSTED_FAN_SPEED=$(($(($(($HIGHEST_TEMP-$TEMP_LOW))*$FAN_PWM_INCREMENTS))+($PWM_LOW+$PWM_ON_OFFSET)))
+      ADJUSTED_PERCENT_SPEED=$(($(($ADJUSTED_FAN_SPEED*100))/$PWM_HIGH))
+      ADJUSTED_OUTPUT=$ADJUSTED_FAN_SPEED
     else
       ADJUSTED_FAN_SPEED=$(($(($(($HIGHEST_TEMP-$TEMP_LOW))*$FAN_PWM_INCREMENTS))+$PWM_LOW))
       ADJUSTED_PERCENT_SPEED=$(($(($ADJUSTED_FAN_SPEED*100))/$PWM_HIGH))
@@ -264,6 +275,7 @@ function_change_fan_speed() {
 }
 
 # Main Loop
+ADJUSTED_OUTPUT="OFF"
 while [[ -f $lockfile ]]; do
   # Just wait if modules aren't loaded
   if [[ ! -f $PWM_FAN || ! -f $PWM_CONTROLLER ]]; then
@@ -272,7 +284,11 @@ while [[ -f $lockfile ]]; do
   fi
 
   # Set PWM_OFF
-  PWM_OFF=$(($PWM_LOW-5))  # Off Value (note: many PWM fans will not turn off)
+  PWM_OFF=$(($PWM_LOW-$PWM_OFF_OFFSET))  # Off Value (note: many PWM fans will not turn off)
+
+  if [[ $PWM_OFF -lt 0 ]]; then
+    PWM_OFF=0
+  fi
 
   # Disable fan mininum RPM
   FAN_RPM_MIN=$(echo ${PWM_FAN} | cut -d"_" -f1)"_min"
@@ -304,8 +320,8 @@ done &
 # to get it to stop, type: rm /var/lock/fan_speed.LCK
 background_pid=$!
 echo $background_pid > "${lockfile}"
-echo "$program_name process ID $background_pid started, To terminate it, type: $program_name -q" >&2
-echo "$program_name process ID $background_pid started, To terminate it, type: $program_name -q" | logger -t$program_name
+echo "$program_name process ID $background_pid started, To terminate it, type: $program_name -q -c $PWM_CONTROLLER -f $PWM_FAN" >&2
+echo "$program_name process ID $background_pid started, To terminate it, type: $program_name -q -c $PWM_CONTROLLER -f $PWM_FAN" | logger -t$program_name
 if [[ -n $EXCLUDE ]]; then
 echo "$program_name excluding drives $EXCLUDE from max temp calculations" | logger -t$program_name
 fi

--- a/source/system-autofan/scripts/rc.autofan
+++ b/source/system-autofan/scripts/rc.autofan
@@ -1,27 +1,52 @@
 #!/bin/bash
+#=======================================================================================
+#  Name:  rc.autofan
+#=======================================================================================
+#  Description:
+#
+#  This script has the aim to control autofan script
+#  How to invoke in your "go" script (copy to /boot/scripts):
+#  chmod +x /boot/scripts/fan_speed.sh -- superseeded by Dynamix plugin
+#  /boot/fan_speed.sh                  -- superseeded by Dynamix plugin
+#=======================================================================================
+# Version 1.0   Authored by Aiden
+# Version 1.1   Modified by Dan Stroot to run in a loop. Does not require the user
+#               to add this to cron  - just start it in your go file.
+# Version 1.2   Modified by Guzzi    - removed -d ata to work on sas controllers
+# Version 1.3   Modified by gfjardim - added to dynamix.system.autofan
+# Version 1.4   Modified by Bergware - added additional line parameters
+#                                    - start/stop control by Dynamix plugin
+#                                    - celsius/fahrenheit conversion
+# Version 1.5   Modified by Bergware - added nvme devices temperature reading (contributed by syntactic-salt)
+#                                    - added exclude disks from temperature reading (contributed by andreiio)
+# Version 1.6   Modified by InfinityMod - added multifan support
+#                                       - added fan spin up/down offset 
 plugin=dynamix.system.autofan
 script=autofan
 execute=/usr/local/emhttp/plugins/$plugin/scripts/$script
+cfg_path=/boot/config/plugins/$plugin
 
-if [[ -f /boot/config/plugins/$plugin/$plugin.cfg ]]; then
-  . /boot/config/plugins/$plugin/$plugin.cfg
+if [[ -f $cfg_path/$plugin.cfg ]]; then
+  . $cfg_path/$plugin.cfg
 else
   echo "No config file, aborting."
   exit 2
 fi
 
 autofan.start() {
-  if [[ -z $(pgrep -f $execute) ]]; then
-    $execute $options 1>/dev/null 2>&1
-    echo "$script started"
-  else
-    echo "$script already running!"
-  fi
+  for i in $cfg_path/$plugin.*.cfg; do
+    . $i
+    if [ "$service" -eq "1" ]; then
+      $execute $options 1>/dev/null 2>&1
+      echo "$script started"
+    fi
+  done 
 }
 
 autofan.stop() {
-  if [[ -n $(pgrep -f $execute) ]]; then
-    $execute -q 1>/dev/null 2>&1
+  for i in $cfg_path/$plugin.*.cfg; do
+    . $i
+    $execute -c $controller -f $fan -q 1>/dev/null 2>&1
     timer=5
     until [[ -z $(pgrep -f $execute) || $timer -eq 0 ]]; do
       timer=$((timer-1))
@@ -30,9 +55,7 @@ autofan.stop() {
     # set fan to max
     echo 255 > $controller
     echo "$script stopped"
-  else
-    echo "$script not running!"
-  fi
+  done
 }
 
 autofan.speed() {
@@ -45,7 +68,7 @@ autofan.speed() {
 
 autofan.restart() {
   autofan.stop
-  sleep 1
+  sleep 2
   autofan.start
 }
 


### PR DESCRIPTION
The request aims to bring a multi-fan control ability into the plugin.
Each fan can configured independently after the commit.
All configured fans are observed and regulated separately.