### PR TITLE
AutoFan: Remove NVME partition during exclude matching

### DIFF
--- a/source/system-autofan/scripts/autofan
+++ b/source/system-autofan/scripts/autofan
@@ -171,7 +171,7 @@ flash=/dev/$(ls -l /dev/disk/by-label| grep UNRAID | cut -d/ -f3 | cut -c 1-3)
 if [[ -z $EXCLUDE ]]; then
   DRIVES=$(ls /dev/{[hs]d*[a-z],nvme[0-9]} | grep -v "$flash")
 else
-  DRIVES=$(ls /dev/{[hs]d*[a-z],nvme[0-9]} | grep -v "$flash" | grep -v "/dev/$(echo $EXCLUDE | sed -e $'s/,/\\\n/g')")
+  DRIVES=$(ls /dev/{[hs]d*[a-z],nvme[0-9]} | grep -v "$flash" | grep -v "/dev/$(echo $EXCLUDE | sed -e $'s/,/\\\n/g' | sed -e 's/[np][0-9]//g')")
 fi
 
 # Count the number of drives in your array (ignoring the flash drive we identified)


### PR DESCRIPTION
https://github.com/bergware/dynamix/blob/016494e63453fae026a6d794721984a16f1f42a1/source/system-autofan/scripts/autofan#L174

According to this line, NVME device with partition (like nvme0n1, which the format unraid is using now) will not be exclude.

This PR will make NVME excluding work.