### PR TITLE
Add unassigned disks

### DIFF
--- a/source/system-autofan/FanSettings.page
+++ b/source/system-autofan/FanSettings.page
@@ -185,6 +185,9 @@ _(Exclude drives)_:
   <?foreach (array_filter($disks,'cache_disks') as $disk):?>
   <?=mk_option_check($cfg['exclude'],$disk['device'],sprintf('%s (%s)',_(my_disk($disk['name']),3),$disk['device']))?>
   <?endforeach;?>
+  <?foreach ($devs as $disk):?>
+  <?=mk_option_check($cfg['exclude'], $disk['device'],sprintf('%s (%s)',_($disk['id'],3),$disk['device']))?>
+  <?endforeach;?>
   </select>
 
 <input type="submit" name="#default" value="_(Default)_">


### PR DESCRIPTION
This allows to exclude unassigned disks from temperature checking.


This is my very first feature./fix for anything unraid related.
I've not really an idea if the global `$dev` might ever include something different then disks so this should be checked.
I tried to solve my problem that i've got an nvme as unassigned disk which is only used for my vm.
So i came up with this.