### PR TITLE
File Integrity: speed up bash by reduce expensive calls

### DIFF
--- a/source/file-integrity/scripts/bunker
+++ b/source/file-integrity/scripts/bunker
@@ -585,12 +585,13 @@ v|V|u)
   fi
   prepare 2
   if [[ $files -gt 0 ]]; then
+     [[ $((scandate/86400)) -le $epoch ]] && scan_all=1 # skip getfattr syscalls
     [[ $job -ne 0 ]] && record start
     while read -r line; do
       ((index++))
       [[ $update -ne 0 ]] && progress "Currently processing file $index of $files. Skipped: $skip files. Found: $warning mismatches, $bad corruptions" $index
       file="${line:$name}"
-      userdate=$(getfattr -n user.scandate --only-values --absolute-names "$file" 2>/dev/null)
+      [[ $scan_all -ne 1 ]] && userdate=$(getfattr -n user.scandate --only-values --absolute-names "$file" 2>/dev/null)
       if [[ -z $userdate || $((userdate/86400)) -le $epoch ]]; then
         [[ $cmd != v ]] && setfattr -n user.scandate -v "$scandate" "$file"
         calculate_hash_and_filestat

--- a/source/file-integrity/scripts/bunker
+++ b/source/file-integrity/scripts/bunker
@@ -212,6 +212,27 @@ prepare() {
   fi
 }
 
+calculate_hash_and_filestat() {
+  declare -a filestat=($(stat -c "%Y %s" "$file"))
+  filedate=${filestat[0]}
+  filesize=${filestat[1]}
+  if [[ $con -eq 0 ]]; then #don't waste ressources if no console output requested
+    key=$($exec $argv "$file")
+    key=${key%% *}
+  else
+    if [[ $filesize -gt $large_file_size ]]; then
+      #use expenive async processing with wait only for files which are taking longer then one secound to process
+      $exec $argv "$file" >$tmpfile.0 &
+      waitfor $! "Calculating ${hash^^} hash key of ${rt}$file"
+      key=$(grep -Po '^\S+' $tmpfile.0)
+    else
+      echo -en "\rCalculating ${hash^^} hash key of ${rt}$file..."
+      key=$($exec $argv "$file")
+      key=${key%% *}
+    fi
+  fi
+}
+
 # Convert value to bytes, used in find
 convert() {
   local unit
@@ -383,6 +404,7 @@ con=1
 mon=0
 job=0
 not=0
+large_file_size=100000000 #use size which can not be processed twice in one sec
 
 # Parse user options
 while getopts ":aAvVueicCrRf:d:D:s:S:m:b:lLnq1xjzE:F:" option; do
@@ -523,11 +545,7 @@ a|A)
     while read -r file; do
       ((index++))
       [[ $update -ne 0 ]] && progress "Currently processing file $index of $files" $index
-      $exec $argv "$file" >$tmpfile.0 &
-      waitfor $! "Calculating ${hash^^} hash key of ${rt}$file"
-      key=$(grep -Po '^\S+' $tmpfile.0)
-      filedate=$(stat -c %Y "$file")
-      filesize=$(stat -c %s "$file")
+      calculate_hash_and_filestat
       setfattr -n user.$hash -v "$key" "$file"
       setfattr -n user.scandate -v "$scandate" "$file"
       setfattr -n user.filedate -v "$filedate" "$file"
@@ -575,15 +593,11 @@ v|V|u)
       userdate=$(getfattr -n user.scandate --only-values --absolute-names "$file" 2>/dev/null)
       if [[ -z $userdate || $((userdate/86400)) -le $epoch ]]; then
         [[ $cmd != v ]] && setfattr -n user.scandate -v "$scandate" "$file"
-        $exec $argv "$file" >$tmpfile.0 &
-        waitfor $! "Verifying ${hash^^} hash key of ${rt}$file"
-        key=$(grep -Po '^\S+' $tmpfile.0)
+        calculate_hash_and_filestat
         ((count++))
         if [[ $key != ${line:0:$code} ]]; then
           filedato=$(getfattr -n user.filedate --only-values --absolute-names "$file" 2>/dev/null)
           filesizo=$(getfattr -n user.filesize --only-values --absolute-names "$file" 2>/dev/null)
-          filedate=$(stat -c %Y "$file")
-          filesize=$(stat -c %s "$file")
           ((fail++))
           if [[ $filedato -ne $filedate || $filesizo -ne $filesize ]]; then
             ((warning++))
@@ -683,8 +697,9 @@ i)
       if [[ -f $file ]]; then
         ((count++))
         key=${line:0:$code}
-        filedate=$(stat -c %Y "$file")
-        filesize=$(stat -c %s "$file")
+        declare -a filestat=($(stat -c "%Y %s" "$file"))
+        filedate=${filestat[0]}
+        filesize=${filestat[1]}
         setfattr -n user.$hash -v "$key" "$file"
         setfattr -n user.scandate -v "$scandate" "$file"
         setfattr -n user.filedate -v "$filedate" "$file"
@@ -718,13 +733,9 @@ c|C)
       [[ $update -ne 0 ]] && progress "Currently processing file $index of $files. Skipped: $skip files. Found: $warning mismatches, $bad corruptions" $count
       file="${line:$name}"
       if [[ -f $file ]]; then
-        $exec $argv "$file" >$tmpfile.0 &
-        waitfor $! "Checking ${hash^^} hash key of ${rt}$file"
-        key=$(grep -Po '^\S+' $tmpfile.0)
+        calculate_hash_and_filestat
         ((count++))
         if [[ $key != ${line:0:$code} ]]; then
-          filedate=$(stat -c %Y "$file")
-          filesize=$(stat -c %s "$file")
           filedato=$(getfattr -n user.filedate --only-values --absolute-names "$file" 2>/dev/null)
           filesizo=$(getfattr -n user.filesize --only-values --absolute-names "$file" 2>/dev/null)
           ((fail++))


### PR DESCRIPTION
async hashing only on console for files which are take longer than 1 sec
call file stat only once

Benchmarks:

Branch Master with BLAKE2
added 178809 files. Duration: 02:20:39. Average speed: 57.4 MB/s
exported 178809 files, skipped 0 files. Duration: 00:01:16
checked 178809 files, skipped 0 files. Found: 0 mismatches, 0 corruptions. Duration: 02:10:46. Average speed: 61.8 MB/s
imported 178809 files, skipped 0 files. Duration: 00:16:06
cleared 178809 files, skipped 0 files. Duration: 00:13:11

Pullrequest with BLAKE2
added 178809 files. Duration: 01:34:01. Average speed: 85.9 MB/s
exported 178809 files, skipped 0 files. Duration: 00:01:15
checked 178809 files, skipped 0 files. Found: 0 mismatches, 0 corruptions. Duration: 01:14:01. Average speed: 109 MB/s

Most important was the replacement of grep by bash string operations.
Executing file stat only once does affect you if you have many small files, like in my benchmark.