### PR TITLE
File Integrity: use check list to speed up check button

### DIFF
--- a/source/file-integrity/scripts/bunker
+++ b/source/file-integrity/scripts/bunker
@@ -709,22 +709,21 @@ c|C)
   check_cmd
   [[ $cmd == c ]] && text="" || text=" (updated)"
   sed '/^$/d;/^#/d' "$store" >$tmpfile &
-  waitfor $! "Preparing for import"
+  waitfor $! "Preparing for check"
   prepare 2
   if [[ $files -gt 0 ]]; then
     [[ $job -ne 0 ]] && record start
-    while read -r line; do
+    sed -i 's/ ./  /' $tmpfile
+    while read -r checkresult; do
       ((index++))
+      ((count++))
       [[ $update -ne 0 ]] && progress "Currently processing file $index of $files. Skipped: $skip files. Found: $warning mismatches, $bad corruptions" $count
-      file="${line:$name}"
-      if [[ -f $file ]]; then
-        $exec $argv "$file" >$tmpfile.0 &
-        waitfor $! "Checking ${hash^^} hash key of ${rt}$file"
-        key=$(grep -Po '^\S+' $tmpfile.0)
-        ((count++))
-        if [[ $key != ${line:0:$code} ]]; then
-          filedate=$(stat -c %Y "$file")
-          filesize=$(stat -c %s "$file")
+      if [[ "${checkresult##*: }" != "OK" ]]; then
+        file=${checkresult%%: *}
+        if [[ -f $file ]]; then
+          declare -a filestat=($(stat -c "%Y %s" "$file"))
+          filedate=${filestat[0]}
+          filesize=${filestat[1]}
           filedato=$(getfattr -n user.filedate --only-values --absolute-names "$file" 2>/dev/null)
           filesizo=$(getfattr -n user.filesize --only-values --absolute-names "$file" 2>/dev/null)
           ((fail++))
@@ -743,14 +742,14 @@ c|C)
             echo "${hash^^} hash key mismatch, $file is corrupted" >>$tmpfile.2
             log "error: ${hash^^} hash key mismatch, $file is corrupted" 1
           fi
+        else
+         ((skip++))
+          echo "$file is missing" >>$tmpfile.2
+          log "warning: $file is missing" 1
         fi
-      else
-        ((skip++))
-        echo "$file is missing" >>$tmpfile.2
-        log "warning: $file is missing" 1
       fi
       [[ $timer -ne $SECONDS ]] && update
-    done <$tmpfile
+    done < <($exec $argv -c $tmpfile)
     update
     [[ $job -ne 0 ]] && record stop
   fi


### PR DESCRIPTION
Because Check button gets manually pressed by user, this process needs special attention and deserve it to be tuned by calling the hash binary only once with list parameter instead of 178809 times

Check result of Master with BLAKE2
Finished - checked 178809 files, skipped 0 files. Found: 0 mismatches, 0 corruptions. Duration: 02:10:46. Average speed: 61.8 MB/s

Check result of Branch Bincalls with BLAKE2
Finished - checked 178809 files, skipped 0 files. Found: 0 mismatches, 0 corruptions. Duration: 01:14:01. Average speed: 109 MB/s

Check result of this pull request with BLAKE2
Finished - checked 178809 files, skipped 0 files. Found: 0 mismatches, 0 corruptions. Duration: 00:48:12. Average speed: 167 MB/s