### PR TITLE
File Integrity: avoid indexing of filesystem while watching progress

### DIFF
--- a/unRAIDv6/dynamix.file.integrity.plg
+++ b/unRAIDv6/dynamix.file.integrity.plg
@@ -402,6 +402,7 @@ day=0; new=0; old=0
 for disk in $disks; do
   hdd=${disk:5}
   [[ -n $gui && -z $(hdparm -C /dev/$(dev $hdd) 2>/dev/null|grep -o active) ]] && continue
+  [[ -n $gui && -f /var/tmp/${hdd}.tmp ]] && continue #skip disk monitoring if user is watching progressbar
   find $disk -type f -name "*" -newer $tmpfile.0 -exec getfattr -n user.$hash --absolute-names "{}" 1>/dev/null 2>$tmpfile +
   # new files in the past 24 hours
   filter 0

--- a/unRAIDv6/dynamix.file.integrity.plg
+++ b/unRAIDv6/dynamix.file.integrity.plg
@@ -307,6 +307,7 @@ plugin=dynamix.file.integrity
 conf=/etc/inotifywait.conf
 path=/boot/config/plugins/$plugin
 
+pidof -x exportrotate -o %PPID >/dev/null && exit 0 #is already running, don't execute this IO intensive task twice
 [[ -f /proc/mdstat ]] && mdstat=mdstat || mdstat=mdcmd
 [[ ! -f $conf || $(grep -Po '^mdState=\K.*' /proc/$mdstat) != STARTED || ! -f $path/disks.ini ]] && exit 0
 gui=$1


### PR DESCRIPTION
If you have many files on the disk, even filtered find calls are expensive.

Before this change:
Finished - checked 178809 files, skipped 0 files. Found: 0 mismatches, 0 corruptions. Duration: 01:01:17. Average speed: 131 MB/s

With this Pullrequest:
Finished - checked 178809 files, skipped 0 files. Found: 0 mismatches, 0 corruptions. Duration: 00:48:12. Average speed: 167 MB/s