### PR TITLE
File Integrity: avoid terminal wrap during progress

### DIFF
--- a/source/file-integrity/scripts/bunker
+++ b/source/file-integrity/scripts/bunker
@@ -68,11 +68,13 @@ usage() {
   echo "bunker -r -f /tmp/errors.hash                          remove SHA key for files listed in file errors.hash - no path"
 }
 
-# Screen controls
+# Screen controls needs to be manually defined because screen doesn't know tput rmam
 clr='\r\033[K'
 cln='\n\033[K'
 up='\033[A'
 rt='\033[K'
+rmam='\033[?7l'
+smam='\033[?7h'
 
 # Wait for background process to finish
 waitfor() {
@@ -93,7 +95,7 @@ waitfor() {
 
 # Print result on console
 con() {
-  [[ $con -ne 0 ]] && echo -en "${clr}$1${cln}"
+  [[ $con -ne 0 ]] && echo -en "${clr}$1${rt}${cln}"
   [[ $mon -ne 0 ]] && echo -n "100%#<span class='green-text green-button'>$task</span> $1#" >$monitor
 }
 
@@ -338,6 +340,7 @@ function check_cmd() {
 
 # Give termination message
 function ctrl_c() {
+  echo -en ${smam}
   con=1
   con "Program terminated."
   exit
@@ -520,6 +523,7 @@ a|A)
   prepare 1
   if [[ $files -gt 0 ]]; then
     [[ $job -ne 0 ]] && record start
+    [[ $con -ne 0 ]] && echo -en ${rmam}
     while read -r file; do
       ((index++))
       [[ $update -ne 0 ]] && progress "Currently processing file $index of $files" $index
@@ -538,6 +542,7 @@ a|A)
     update
     [[ -s $tmpfile.2 && $one -eq 0 ]] && sort -fk2 -o "$store" $tmpfile.2
     [[ -s $tmpfile.2 && $one -eq 1 ]] && cat $tmpfile.2 >>"$store"
+    [[ $con -ne 0 ]] && echo -en ${smam}
     [[ $job -ne 0 ]] && record stop
   fi
   con "Finished - added $(plural $index file).$(score $index)"
@@ -568,6 +573,7 @@ v|V|u)
   prepare 2
   if [[ $files -gt 0 ]]; then
     [[ $job -ne 0 ]] && record start
+    [[ $con -ne 0 ]] && echo -en ${rmam}
     while read -r line; do
       ((index++))
       [[ $update -ne 0 ]] && progress "Currently processing file $index of $files. Skipped: $skip files. Found: $warning mismatches, $bad corruptions" $index
@@ -614,6 +620,7 @@ v|V|u)
     [[ -s $tmpfile.3 ]] && cat $tmpfile.3 >>$tmpfile.2
     [[ -s $tmpfile.2 && $one -eq 0 ]] && sort -fk2 -o "$store" $tmpfile.2
     [[ -s $tmpfile.2 && $one -eq 1 ]] && cat $tmpfile.2 >>"$store"
+    [[ $con -ne 0 ]] && echo -en ${smam}
     [[ $job -ne 0 ]] && record stop
   fi
   [[ $msg -ne 0 && ($bad -ne 0 || $warning -ne 0) ]] && notify "bunker verify command"
@@ -713,6 +720,7 @@ c|C)
   prepare 2
   if [[ $files -gt 0 ]]; then
     [[ $job -ne 0 ]] && record start
+    [[ $con -ne 0 ]] && echo -en ${rmam}
     while read -r line; do
       ((index++))
       [[ $update -ne 0 ]] && progress "Currently processing file $index of $files. Skipped: $skip files. Found: $warning mismatches, $bad corruptions" $count
@@ -752,6 +760,7 @@ c|C)
       [[ $timer -ne $SECONDS ]] && update
     done <$tmpfile
     update
+    [[ $con -ne 0 ]] && echo -en ${rmam}
     [[ $job -ne 0 ]] && record stop
   fi
   [[ -s $tmpfile.3 ]] && cat $tmpfile.3 >>$tmpfile.2


### PR DESCRIPTION
and fix wrap clear issue after progress output