### PR TITLE
File Integrity: monitor verifications and all manual bunker calls

### DIFF
--- a/source/file-integrity/FileIntegrityControl.page
+++ b/source/file-integrity/FileIntegrityControl.page
@@ -42,6 +42,11 @@ $size = $cfg['method']=='-b2' ? 128 : ($cfg['method']=='-md5' ? 32 : 64);
 $root = $cfg['place']=='SystemInformation' ? '/Tools/Integrity' : '/Integrity';
 $data = array_filter($disks,'data_disks');
 
+$existingDiskTasks=array();
+
+$command="ps -eo comm,args | gawk '$1==\"bunker\" && match($0,/\/mnt\/disk([0-9]*)|\/disk([0-9]*)\.export\.hash$/,d){print substr($4,2,1) d[1]}'";
+exec($command, $existingDiskTasks);
+
 ?>
 <style>
 input.thin{margin:1px;}
@@ -130,9 +135,16 @@ function corz() {
   openBox('/plugins/<?=$plugin?>/scripts/corzation'+args.slice(0,-1)+'&arg2=<?=$size?>','_(Generate Corz Files)_',490,430,false);
 }
 $(function() {
+  var existingDiskTasks='<?=implode(",", $existingDiskTasks)?>';
+  var disksCookie = $.cookie('disks') != null ? $.cookie('disks') : '';
+  if(existingDiskTasks){
+    disksCookie = existingDiskTasks.split(",").filter(d => disksCookie.indexOf(d[1]) == -1)
+                      .concat(disksCookie.split(',')).filter(d=>d).join(',');
+    $.cookie('disks',disksCookie,{path:'/',expires:3650});
+  }
   updater();
-  if ($.cookie('disks') != null) {
-    var cookies = $.cookie('disks').split(',');
+  if (disksCookie) {
+    var cookies = disksCookie.split(',');
     for (var i=0,cookie; cookie=cookies[i]; i++) {
       var cmd = cookie.substr(0,1);
       var disk = cookie.substr(1);

--- a/source/file-integrity/FileIntegrityControl.page
+++ b/source/file-integrity/FileIntegrityControl.page
@@ -44,7 +44,7 @@ $data = array_filter($disks,'data_disks');
 
 $existingDiskTasks=array();
 
-$command="ps -eo comm,args | gawk '$1==\"bunker\" && match($0,/\/mnt\/disk([0-9]*)|\/disk([0-9]*)\.export\.hash$/,d){print substr($4,2,1) d[1]}'";
+$command="ps -eo comm,args | gawk '$1==\"bunker\" && match($0,/\/mnt\/disk([0-9]*)|\/disk([0-9]*)\.export\.hash$/,d){print substr($4,2,1) d[1]d[2]}'";
 exec($command, $existingDiskTasks);
 
 ?>

--- a/source/file-integrity/FileIntegrityControl.page
+++ b/source/file-integrity/FileIntegrityControl.page
@@ -138,8 +138,10 @@ $(function() {
   var existingDiskTasks='<?=implode(",", $existingDiskTasks)?>';
   var disksCookie = $.cookie('disks') != null ? $.cookie('disks') : '';
   if(existingDiskTasks){
-    disksCookie = existingDiskTasks.split(",").filter(d => disksCookie.indexOf(d[1]) == -1)
-                      .concat(disksCookie.split(',')).filter(d=>d).join(',');
+    disksCookie = existingDiskTasks.split(",").concat(disksCookie.split(','))
+      .filter(d=>!isNaN(d[1])) //remove unexpected ps parings errors
+      .filter((item, pos, self)=>self.findIndex(ele => ele.includes(item[1])) == pos) //remove unexpected duplicates
+      .join(',');
     $.cookie('disks',disksCookie,{path:'/',expires:3650});
   }
   updater();

--- a/source/file-integrity/include/BunkerProcess.php
+++ b/source/file-integrity/include/BunkerProcess.php
@@ -11,7 +11,7 @@
 ?>
 <?
 $disk = 'disk'.$_POST['disk'];
-$filter = "bunker -{$_POST['cmd']}q.*(\/mnt\/$disk ?|\/$disk\.export\.hash$)";
+$filter = "bunker -{$_POST['cmd']}.*(\/mnt\/$disk ?|\/$disk\.export\.hash$)";
 $pid = exec("ps -eo pid,comm,args|awk '$2==\"bunker\" && $0~/$filter/{print $1}'");
 if ($_POST['kill']=='true') {
   exec("pgrep -P $pid 2>/dev/null", $cpids);

--- a/source/file-integrity/include/ProgressInfo.php
+++ b/source/file-integrity/include/ProgressInfo.php
@@ -37,7 +37,7 @@ if ($_POST['disk']>0) {
     echo file_get_contents($tmp);
   } else {
     echo file_exists($end) ? file_get_contents($end) : "100%#<span class='red-text red-button'>"._('Error')."</span>"._('Operation aborted')."#";
-    @unlink($end);
+    //don't delete end file because there could be a race condition if you submit forms or reload the page for any other reason
   }
 } else {
   $ctrl = "/var/tmp/ctrl.tmp";

--- a/source/file-integrity/scripts/bunker
+++ b/source/file-integrity/scripts/bunker
@@ -380,7 +380,7 @@ log=0
 one=0
 msg=0
 con=1
-mon=0
+mon=1 #allways write progress to file, even if not requested
 job=0
 not=0
 

--- a/source/file-integrity/scripts/bunker
+++ b/source/file-integrity/scripts/bunker
@@ -493,6 +493,7 @@ if [[ $mon -ne 0 ]]; then
     z=${store##*/}
     monitor=/var/tmp/${z%%.*}.tmp
   fi
+  rm -f $monitor.end #remove old monitor finish file from previous job to make sure that an unclean exit can be detected
 fi
 
 # Time stamp


### PR DESCRIPTION
Somebody did point out that the scheduled verifications are not monitored.
https://forums.unraid.net/topic/43290-dynamix-file-integrity-plugin/?do=findComment&comment=1005706

I did extend this request by monitor all bunker calls to monitor my testing in the UI as well.