### PR TITLE
File Integrity: fix inline help for disk table and commands

### DIFF
--- a/source/file-integrity/FileIntegrityControl.page
+++ b/source/file-integrity/FileIntegrityControl.page
@@ -129,6 +129,11 @@ function corz() {
   });
   openBox('/plugins/<?=$plugin?>/scripts/corzation'+args.slice(0,-1)+'&arg2=<?=$size?>','_(Generate Corz Files)_',490,430,false);
 }
+function toogleCommandHelp() {
+  if (['button', 'input'].indexOf(event.target.localName) == -1) {
+    $('.inline_help:last').toggle('slow');
+  }
+}
 $(function() {
   updater();
   if ($.cookie('disks') != null) {
@@ -190,6 +195,7 @@ _(Excluded files)_:
 > This is the list of excluded files as selected on the settings page. Make sure it is correct before you perform any commands on this page.
 :end
 
+<table class="share_status fixed" onclick="toogleCommandHelp()" style="margin:20px 0; cursor: help;">
 <?
 $row1 = $row2 = [];
 foreach ($data as $disk) {
@@ -197,14 +203,15 @@ foreach ($data as $disk) {
   $row2[] = "<td><input type='checkbox' name='{$disk['name']}' class='selection' onchange='updateList(this.checked,this.name)'></td>";
 }
 $x = 28-count($row1);
-echo "<table class='share_status fixed' style='margin:20px 0'><thead><tr><td id='delayed' style='width:10%'></td>";
+echo "<thead><tr><td id='delayed' style='width:10%'></td>";
 echo implode('',$row1);
 echo str_repeat("<td>-</td>", $x);
 echo "</tr></thead><tbody><tr><td style='font-weight:bold'>"._('Disk selection')."</td>";
 echo implode('',$row2);
 echo str_repeat("<td></td>", $x);
-echo "</tr></tbody><tbody id='disk-status'></tbody></table>";
+echo "</tr></tbody><tbody id='disk-status'></tbody>";
 ?>
+</table>
 
 :integrity_control_overview_plug:
 > Select the disks which you want to let participate in any of the commands below. You can execute a command multiple times with different selections.
@@ -226,7 +233,7 @@ echo "</tr></tbody><tbody id='disk-status'></tbody></table>";
 > Use the **Export** command to generate checksum files which can be used for manual checking or restoration.
 > These files are stored on the flash disk under */config/plugins/dynamix.file.integrity/diskXX.export.hash*
 >
-> Use the **Check** command to verify files against a previously exported file. This allows for off-line verification in case of a local issue and the extended attributes can't be used.
+> Use the **Check Export** command to verify files against a previously exported file. This allows for off-line verification in case of a local issue and the extended attributes can't be used.
 >
 > Use the **Import** command to restore the extended attributes from a previously exported file. This *should* only be necessary in case the extended attributes got corrupted or went missing.
 >
@@ -239,10 +246,11 @@ echo "</tr></tbody><tbody id='disk-status'></tbody></table>";
 > Use the **Find** command to search for duplicate file names and file hashes in the exported *hash* files.
 :end
 
-&nbsp;
-: <input type="submit" name="cmd" value="_(Build)_"  onclick="this.form.x.value='a'">
+<p onclick="toogleCommandHelp()" style="text-align: right; cursor: help;">
+<span class="small">
+  <input type="submit" name="cmd" value="_(Build)_"  onclick="this.form.x.value='a'">
   <input type="submit" name="cmd" value="_(Export)_" onclick="this.form.x.value='e'">
-  <input type="submit" name="cmd" value="_(Check)_"  onclick="this.form.x.value='C'">
+  <input type="submit" name="cmd" value="_(Check)_ _(Export)_"  onclick="this.form.x.value='C'">
   <input type="submit" name="cmd" value="_(Import)_" onclick="this.form.x.value='i'">
   <input type="submit" name="cmd" value="_(Remove)_" onclick="this.form.x.value='R'">
   <input type="submit" name="cmd" value="_(Clear)_"  onclick="this.form.x.value='R'">
@@ -251,7 +259,9 @@ echo "</tr></tbody><tbody id='disk-status'></tbody></table>";
 <?if ($cfg['place']=='SystemInformation'):?>
   <input type="button" value="_(Done)_" class="lock" onclick="done()">
 <?endif;?>
-<span class="small" style="float:right">_(Include duplicate file hashes in **Find** command)_ &nbsp;<input type='checkbox' name='#more'></span>
+_(Include duplicate file hashes in **Find** command)_ &nbsp;<input type='checkbox' name='#more'>
+</span>
+</p>
 </form>
 
 <table class='tablesorter'>

--- a/source/file-integrity/FileIntegrityControl.page
+++ b/source/file-integrity/FileIntegrityControl.page
@@ -60,7 +60,7 @@ var bunker = [];
 function updater() {
   $.post('/plugins/<?=$plugin?>/include/ProgressInfo.php',{disk:0,time:180},function(data){
     $('#disk-status').html(data);
-    $('input[value="_(Find)_"]').prop('disabled',$('#export-status').html().search('green-text')==-1);
+    $('#findbtn').prop('disabled',$('#export-status').html().search('green-text')==-1);
     setTimeout(updater,3000);
   });
 }
@@ -256,7 +256,7 @@ echo "</tr></tbody><tbody id='disk-status'></tbody>";
   <input type="submit" value="_(Remove)_" onclick="this.form.cmd.value='R'">
   <input type="submit" value="_(Clear)_"  onclick="this.form.cmd.value='R';this.form.excludeonly.value=true">
   <input type="button" value="_(Corz)_" onclick="corz()">
-  <input type="button" value="_(Find)_" onclick="duplicates()">
+  <input type="button" value="_(Find)_" id="findbtn" onclick="duplicates()">
 <?if ($cfg['place']=='SystemInformation'):?>
   <input type="button" value="_(Done)_" class="lock" onclick="done()">
 <?endif;?>

--- a/source/file-integrity/FileIntegrityControl.page
+++ b/source/file-integrity/FileIntegrityControl.page
@@ -162,7 +162,7 @@ $(function() {
  <span style="font-style:italic;display:block;text-align:right">_(saved files)_ &nbsp;<a href="<?=$root?>/Browse?dir=/boot/config/plugins/<?=$plugin?>/saved"><img src="/webGui/images/explore.png"></a></span>
  </div>
 
-<form markdown="1" name="integrity_control" method="POST" action="/update.php" target="progressFrame" onsubmit="prepareList(this.x.value)">
+<form markdown="1" name="integrity_control" method="POST" action="/update.php" target="progressFrame" onsubmit="prepareList(this.cmd.value)">
 <input type="hidden" name="#file" value="not-used">
 <input type="hidden" name="#method" value="<?=$cfg['method']?>">
 <input type="hidden" name="#exclude" value="<?=$cfg['exclude']?>">
@@ -173,7 +173,8 @@ $(function() {
 <input type="hidden" name="#priority" value="<?=$cfg['priority']?>">
 <input type="hidden" name="#log" value="<?=$cfg['log']?>">
 <input type="hidden" name="#include" value="plugins/<?=$plugin?>/include/update.control.php">
-<input type="hidden" name="x" value="">
+<input type="hidden" name="cmd" value="">
+<input type="hidden" name="excludeonly" value="false">
 _(Hashing method)_:
 : <span style='font-size:12px;margin-right:8px'><?=$cfg['method']?str_replace(['-b2','-md5'],[_('BLAKE2'),_('MD5')],$cfg['method']):_('SHA2')?></span>
 
@@ -248,12 +249,12 @@ echo "</tr></tbody><tbody id='disk-status'></tbody>";
 
 <p onclick="toogleCommandHelp()" style="text-align: right; cursor: help;">
 <span class="small">
-  <input type="submit" name="cmd" value="_(Build)_"  onclick="this.form.x.value='a'">
-  <input type="submit" name="cmd" value="_(Export)_" onclick="this.form.x.value='e'">
-  <input type="submit" name="cmd" value="_(Check)_ _(Export)_"  onclick="this.form.x.value='C'">
-  <input type="submit" name="cmd" value="_(Import)_" onclick="this.form.x.value='i'">
-  <input type="submit" name="cmd" value="_(Remove)_" onclick="this.form.x.value='R'">
-  <input type="submit" name="cmd" value="_(Clear)_"  onclick="this.form.x.value='R'">
+  <input type="submit" value="_(Build)_"  onclick="this.form.cmd.value='a'">
+  <input type="submit" value="_(Export)_" onclick="this.form.cmd.value='e'">
+  <input type="submit" value="_(Check)_ _(Export)_" onclick="this.form.cmd.value='C'">
+  <input type="submit" value="_(Import)_" onclick="this.form.cmd.value='i'">
+  <input type="submit" value="_(Remove)_" onclick="this.form.cmd.value='R'">
+  <input type="submit" value="_(Clear)_"  onclick="this.form.cmd.value='R';this.form.excludeonly.value=true">
   <input type="button" value="_(Corz)_" onclick="corz()">
   <input type="button" value="_(Find)_" onclick="duplicates()">
 <?if ($cfg['place']=='SystemInformation'):?>

--- a/source/file-integrity/include/update.control.php
+++ b/source/file-integrity/include/update.control.php
@@ -50,8 +50,10 @@ if ($_POST['#priority']) {
   $bunker = "nice $nice ionice $ionice $bunker";
 }
 
+$z = $_POST['excludeonly'] == "true" ? "-z" : "";
+
 switch ($_POST['cmd']) {
-  case 'Build':
+  case 'a':
     $key = $_POST['#files'] ? array_map('trim', explode(',', $_POST['#files'])) : [];
     if ($_POST['#apple']) $key[] = $apple[1];
     $key = $key ? '! "'.implode(',', $key).'"' : '';
@@ -59,12 +61,12 @@ switch ($_POST['cmd']) {
       exec("$bunker -aqx $m $l $e $f -f $path/$disk.export.hash /mnt/$disk $key >/dev/null &");
     }
   break;
-  case 'Export':
+  case 'e':
     foreach ($disks as $disk) {
       exec("$bunker -eqx $m $l $e $f -f $path/$disk.export.hash /mnt/$disk >/dev/null &");
     }
   break;
-  case 'Check':
+  case 'C':
     foreach ($disks as $disk) {
       if (file_exists("$path/$disk.export.hash")) {
         exec("$bunker -Cqx $m $l $n -f $path/$disk.export.hash >/dev/null &");
@@ -73,7 +75,7 @@ switch ($_POST['cmd']) {
       }
     }
   break;
-  case 'Import':
+  case 'i':
     foreach ($disks as $disk) {
       if (file_exists("$path/$disk.export.hash")) {
         exec("$bunker -iqx $m $l -f $path/$disk.export.hash >/dev/null &");
@@ -82,17 +84,12 @@ switch ($_POST['cmd']) {
       }
     }
   break;
-  case 'Remove':
-    foreach ($disks as $disk) {
-      exec("$bunker -Rqx $m $l $e $f /mnt/$disk >/dev/null &");
-    }
-  break;
-  case 'Clear':
+  case 'R':
     $key = $_POST['#files'] ? array_map('trim', explode(',', $_POST['#files'])) : [];
     if ($_POST['#apple']) $key[] = $apple[1];
     $key = $key ? '"'.implode(',', $key).'"' : '';
     foreach ($disks as $disk) {
-      exec("$bunker -Rqxz $m $l $e $f /mnt/$disk $key >/dev/null &");
+      exec("$bunker -Rqx $z $m $l $e $f /mnt/$disk $key >/dev/null &");
     }
   break;
 }


### PR DESCRIPTION
And make it more clear that check does only work after export


This is needed because our commands and table help text is hidden and users like me don't find it. 
Yes, you can open it if you use the global help toggle, but I would have never done this because I did not expect this helptext.