### PR TITLE
File Integrity: Add Disk status refresh icon

### DIFF
--- a/source/file-integrity/FileIntegrityControl.page
+++ b/source/file-integrity/FileIntegrityControl.page
@@ -52,6 +52,8 @@ span.red-button{padding:1px 4px;margin-right:6px;border-radius:4px;border:1px so
 .blue-text{color:#00529B;}
 .usage-disk{height:auto}
 .usage-disk>span:first-child{height:auto;padding:0}
+.fa-refresh{animation: rotate 1.5s linear infinite;}
+@keyframes rotate{to{ transform: rotate(360deg);}}
 </style>
 <script>
 var disks = [];

--- a/source/file-integrity/include/ProgressInfo.php
+++ b/source/file-integrity/include/ProgressInfo.php
@@ -27,6 +27,7 @@ if ($translations) {
 function status($cmd,$name,$file) {
   global $list;
   if (!$file) return "close blue-text";
+  if ($list && strpos($list[$name],"analyse")!==false) return "refresh grey-text";
   return ($list && strpos($list[$name],$cmd)!==false) ? "check green-text" : "circle-o orange-text";
 }
 

--- a/source/file-integrity/scripts/bunker
+++ b/source/file-integrity/scripts/bunker
@@ -805,5 +805,6 @@ r|R)
   fi
   con "Finished - cleared $(plural $count file), skipped $(plural $skip file).$(score)"
   log "cleared $(plural $count file) from $path.$(score)" $count
+  [[ $mon -ne 0 ]] && sed -ri "/${path##*/}/ s/,?build//g" /boot/config/plugins/dynamix.file.integrity/disks.ini
 ;;
 esac

--- a/unRAIDv6/dynamix.file.integrity.plg
+++ b/unRAIDv6/dynamix.file.integrity.plg
@@ -339,7 +339,7 @@ filter() {
     files=$(cat $tmpfile|wc -l)
     if [[ $files -gt 0 ]]; then
       ((day+=$files))
-      sed -ri "s/(^$hdd=[^,]*),?build,?/\1/" $path/disks.ini
+      sed -ri "/$hdd/ s/,?build//g" $path/disks.ini
       echo -n "$hdd," >>$tmpfile.build
     else
       if ! grep -q "^$hdd=" $path/disks.ini; then
@@ -357,7 +357,7 @@ filter() {
     IFS=$ifs
     files=$(grep -c '^#file: ' $tmpfile) ;;
   2)
-    sed -ri "s/(^$hdd=[^,]*),?export,?/\1/" $path/disks.ini
+    sed -ri "/$hdd/ s/,?export//g" $path/disks.ini
     echo -n "$hdd," >>$tmpfile.export
     files=0 ;;
   esac
@@ -402,6 +402,7 @@ day=0; new=0; old=0
 for disk in $disks; do
   hdd=${disk:5}
   [[ -n $gui && -z $(hdparm -C /dev/$(dev $hdd) 2>/dev/null|grep -o active) ]] && continue
+  sed -ri "s/(^$hdd=.*)/\1,analyse/" $path/disks.ini
   find $disk -type f -name "*" -newer $tmpfile.0 -exec getfattr -n user.$hash --absolute-names "{}" 1>/dev/null 2>$tmpfile +
   # new files in the past 24 hours
   filter 0
@@ -433,6 +434,7 @@ for disk in $disks; do
       echo -n "export"
     fi
   fi
+  sed -ri "/$hdd/ s/,?analyse//g" $path/disks.ini
 done
 
 if [[ -z $gui && -n $(get notify) ]]; then


### PR DESCRIPTION
We know have feedback about scaning status
And the sed regex for removing a comma separated value was broken.

![scan](https://user-images.githubusercontent.com/8665625/128567507-89de90d3-7d8b-4c76-9ec6-6ca369664802.gif)
