### PR TITLE
Update s3_sleep

### DIFF
--- a/source/s3-sleep/scripts/s3_sleep
+++ b/source/s3-sleep/scripts/s3_sleep
@@ -234,7 +234,7 @@ HDD_activity() {
     [[ -f /dev/shm/2 ]] && cp -f /dev/shm/2 /dev/shm/1 || touch /dev/shm/1
     awk '/(sd[a-z]*|nvme[0-9]n1) /{print $3,$6+$10}' /proc/diskstats >/dev/shm/2
     for dev in ${array[@]}; do
-      [[ $monitor -ne 2 ]] && active=$(hdparm -C /dev/$dev 2>/dev/null|grep -o active) || active=
+      [[ $monitor -ne 2 ]] && active=$(sdspin /dev/$dev) || active=
       [[ $monitor -ne 1 ]] && diskio=($(grep -Pho "^$dev \K\d+" /dev/shm/1 /dev/shm/2)) || diskio=
       if [[ -n $active || ${diskio[0]} != ${diskio[1]} ]]; then
         result=1


### PR DESCRIPTION
Check for HDD active/spundown via standard Unraid interface, so as to support SAS as well as ATA drives