### PR TITLE
Implement auto-hashing for cache-to-disk moves

### DIFF
--- a/source/file-integrity/scripts/watcher
+++ b/source/file-integrity/scripts/watcher
@@ -23,8 +23,9 @@ busy=$(($(awk '$3~/md/{++c}END{print c}' /proc/diskstats)*512))
 jobs=$(($(nproc)*2))
 
 # setup named pipe and speaker
+# TODO(Torqu3Wr3nch): Update code to handle only file.partial moves caused by the Unraid Mover. 
 [[ -p $pipe ]] || mkfifo $pipe
-inotifywait -dsrqo $pipe -e close_write --exclude "$exclude" --format '%w%f' $disks
+inotifywait -dsrqo $pipe -e close_write,moved_to --exclude "$exclude" --format '%w%f' $disks
 
 # delay execution
 diskio(){


### PR DESCRIPTION
Addresses Issue #78:

When the Unraid Mover runs, a partial file is created on the disk. This file.partial is then moved to the original file name on the disk. Therefore, inotifywait does not see the move as a close_write, but rather a moved_to.

I considered the following options:

- **Option 1:** Configure inotifywait to watch for "moved_to" instead of just "close_write".
-- Cleanest/most straightforward. This was the design I ended up going with.
- **Option 2:** Keep close_write, but then regex to remove the .partial in anticipation that the file will soon exist when the mover completes.
-- Decided against this because the write to disk could take a while and there's no guarantee that it completes.
- **Option 3:** Instead of monitoring disk directories, why not monitor the Fuse directory (i.e. /mnt/user/) itself?
-- This would increase the scope significantly and I assume there is a reason we haven't already done that.

Note that this hotfix will cause normal moves on the disk (i.e. those using the "mv" command) to trigger a rehash. I expect this side-effect to be minimally impactful. I will address that in a future PR.