### PR TITLE
System Stats on Unraid 6.12 displays the reads as writes and displays zero for reads

### DIFF
--- a/source/system-stats/include/HardwareStats.php
+++ b/source/system-stats/include/HardwareStats.php
@@ -101,7 +101,7 @@ case 'rts':
   $hdd = '$2=="tps"';
   $ram = '$2=="kbmemfree"';
   $com = '$2=="'.($_POST['port']??'').'"';
-  exec("sar 1 1 -u -b -r -n DEV|grep -a '^A'|tr -d '\\0'|awk '$cpu {u=$3;n=$4;s=$5;}; $hdd {getline;r=$5;w=$6;}; $ram {getline;f=$2;c=$6+$7;d=$4;}; $com {x=$5;y=$6;} END{print u,n,s{$nl}r,w{$nl}f,c,d{$nl}x,y}'",$data);
+  exec("sar 1 1 -u -b -r -n DEV|grep -a '^A'|tr -d '\\0'|awk '$cpu {u=$3;n=$4;s=$5;}; $hdd {getline;r=$6;w=$7;}; $ram {getline;f=$2;c=$6+$7;d=$4;}; $com {x=$5;y=$6;} END{print u,n,s{$nl}r,w{$nl}f,c,d{$nl}x,y}'",$data);
   echo implode(' ', $data);
   exit;
 case 'cpu':
@@ -124,9 +124,9 @@ case 'com':
   break;
 case 'hdd':
   $series = ['Read','Write'];
-  $data = '$7,$8';
+  $data = '$8,$9';
   $case = '-- -b';
-  $mask = ' && $7<100000000000 && $8<100000000000';
+  $mask = ' && $8<100000000000 && $9<100000000000';
   break;
 }
 $input = [];


### PR DESCRIPTION
The system stats plugin on Unraid 6.12 displays the disk reads as disk writes and always displays zero for disk reads. It works properly using plugin version 2023.02.14 on Unraid 6.11.5 but is does not work on Unraid 6.12.6. A user on the plugin support thread reports that it did not work as far back as Unraid 6.12.0-rc6. I tried upgrading the sysstat package from 12.7.2 to 12.7.5 but the plugin still does not work properly.

It appears that the output of sar and sadf has changed.  This pull request corrects the issue for me.

Relevant comments from the plugin support thread:

https://forums.unraid.net/topic/34889-dynamix-v6-plugins/page/151/#comment-1269924
https://forums.unraid.net/topic/34889-dynamix-v6-plugins/page/155/#comment-1299842
https://forums.unraid.net/topic/34889-dynamix-v6-plugins/page/156/#comment-1315284
https://forums.unraid.net/topic/34889-dynamix-v6-plugins/page/156/#comment-1325259
https://forums.unraid.net/topic/34889-dynamix-v6-plugins/page/157/#comment-1335182