### PR TITLE
Fix checking of drive status using sdspin

### DIFF
--- a/source/s3-sleep/scripts/s3_sleep
+++ b/source/s3-sleep/scripts/s3_sleep
@@ -239,9 +239,11 @@ HDD_activity() {
     [[ -f /dev/shm/2 ]] && cp -f /dev/shm/2 /dev/shm/1 || touch /dev/shm/1
     awk '/(sd[a-z]*|nvme[0-9]n1) /{print $3,$6+$10}' /proc/diskstats >/dev/shm/2
     for dev in ${array[@]}; do
-      [[ $monitor -ne 2 ]] && active=$(sdspin /dev/$dev) || active=
+      [[ $monitor -ne 2 ]] && $(sdspin /dev/$dev) 
+      # sdspin exit codes: 0=spun up, 1=error, 2=spun down
+      sdspinExitCode=$?
       [[ $monitor -ne 1 ]] && diskio=($(grep -Pho "^$dev \K\d+" /dev/shm/1 /dev/shm/2)) || diskio=
-      if [[ -n $active || ${diskio[0]} != ${diskio[1]} ]]; then
+      if [[ $sdspinExitCode -eq 0 || ${diskio[0]} != ${diskio[1]} ]]; then
         result=1
         break;
       fi


### PR DESCRIPTION
Change from #75 replaced using `hdparm` to `sdspin` on how to check if drive is spinning or not, the difference between the two is that `hdparm` returns a string while `sdspin` does not, it only returns exit code. This PR changes the if condition from comparing string from `hdparm` to comparing the exit code from `sdspin`.