### PR TITLE
Bugfix for Unraid 7.0.0

### DIFF
--- a/unRAIDv6/dynamix.system.temp.plg
+++ b/unRAIDv6/dynamix.system.temp.plg
@@ -3,7 +3,7 @@
 <!DOCTYPE PLUGIN [
 <!ENTITY name      "dynamix.system.temp">
 <!ENTITY author    "Bergware">
-<!ENTITY version   "2023.02.04b">
+<!ENTITY version   "2024.07.10">
 <!ENTITY launch    "Settings/TempSettings">
 <!ENTITY pluginURL "https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/&name;.plg">
 <!ENTITY flash     "/boot/config/plugins/&name;">
@@ -16,6 +16,9 @@
 ##&name;
 
 ###&version;
+- bugfix for Unraid version 7.0.0
+
+###2023.02.04b;
 - set minimum Unraid version to 6.9 (supports multi-language)
 - added support for upcoming Unraid version 6.12 
 
@@ -146,13 +149,6 @@ if [[ $MD5 != &MD5; ]]; then
   rm -f &flash;/&name;*.txz
 fi
 
-# Remove sensors-detect script (Unraid 6.7 and earlier)
-source /etc/unraid-version
-version=${version:2:2}
-if [[ $((${version/./}*1)) -lt 8 ]]; then
-  rm -f /usr/sbin/sensors-detect
-fi
-
 # stop nchan script
 if [[ -e /var/run/nchan.pid ]]; then
   pkill system_temp
@@ -165,14 +161,6 @@ fi
 <FILE Name="&flash;/&name;.txz" Run="upgradepkg --install-new --reinstall">
 <URL>https://raw.githubusercontent.com/bergware/dynamix/master/archive/&name;.txz</URL>
 <MD5>&MD5;</MD5>
-</FILE>
-
-<!-- SENSORS-DETECT SCRIPT -->
-<FILE Name="&flash;/sensors-detect" Max="6.7.2">
-<URL>https://raw.githubusercontent.com/bergware/dynamix/master/archive/sensors-detect</URL>
-</FILE>
-<FILE Name="/usr/sbin/sensors-detect" Mode="0755" Max="6.7.2">
-<LOCAL>&flash;/sensors-detect</LOCAL>
 </FILE>
 
 <!-- POST-INSTALL SCRIPT -->


### PR DESCRIPTION
- update plugin to be compatible with Unraid version 7.0.0
- remove package for 6.7.2 because min version is set to 6.9.0