### PR TITLE
Ad the table class to the style tag that does no longer exist in Unraid 7

### DIFF
--- a/source/file-integrity/FileIntegrityControl.page
+++ b/source/file-integrity/FileIntegrityControl.page
@@ -53,6 +53,7 @@ span.red-button{padding:2px 6px;margin-right:6px;border-radius:4px;border:1px so
 .tablesorter a{cursor:pointer;color:red;}
 .fa-refresh{animation: rotate 1.5s linear infinite;}
 @keyframes rotate{to{ transform: rotate(360deg);}}
+table.share_status.fixed tr>td+td{min-width:39px;font-size:1.1rem;text-align:center;padding:0}
 </style>
 <script>
 var disks = [];

--- a/source/file-integrity/FileIntegrityControl.page
+++ b/source/file-integrity/FileIntegrityControl.page
@@ -53,7 +53,20 @@ span.red-button{padding:2px 6px;margin-right:6px;border-radius:4px;border:1px so
 .tablesorter a{cursor:pointer;color:red;}
 .fa-refresh{animation: rotate 1.5s linear infinite;}
 @keyframes rotate{to{ transform: rotate(360deg);}}
+####Unraid 7 Fix####
+table.share_status{white-space:nowrap;margin-top:12px}
+table.share_status thead tr:first-child td{font-size:1.2rem;letter-spacing:1px;text-transform:uppercase;color:#82857e;border-bottom:1px solid #60>
+table.share_status tr>td{text-align:left;padding-left:12px}
+table.share_status tr>td+td{padding-left:0}
+table.share_status tbody tr{border-bottom:1px solid #0c0f0b}
+table.share_status:not(.dashboard) tbody tr:hover td{background-color:rgba(255,255,255,0.05)}
+table.share_status tbody tr:last-child td{border-bottom:1px solid #606e7f}
+table.share_status tbody tr.alert{color:#f0000c}
+table.share_status tbody tr.warn{color:#e68a00}
 table.share_status.fixed tr>td+td{min-width:39px;font-size:1.1rem;text-align:center;padding:0}
+table.share_status.table{margin-top:36px}
+table.share_status.table tr>td{width:50%}
+#####
 </style>
 <script>
 var disks = [];

--- a/source/file-integrity/FileIntegrityControl.page
+++ b/source/file-integrity/FileIntegrityControl.page
@@ -53,9 +53,8 @@ span.red-button{padding:2px 6px;margin-right:6px;border-radius:4px;border:1px so
 .tablesorter a{cursor:pointer;color:red;}
 .fa-refresh{animation: rotate 1.5s linear infinite;}
 @keyframes rotate{to{ transform: rotate(360deg);}}
-####Unraid 7 Fix####
 table.share_status{white-space:nowrap;margin-top:12px}
-table.share_status thead tr:first-child td{font-size:1.2rem;letter-spacing:1px;text-transform:uppercase;color:#82857e;border-bottom:1px solid #60>
+table.share_status thead tr:first-child td{font-size:1.2rem;letter-spacing:1px;text-transform:uppercase;color:#82857e;border-bottom:1px solid #606e7f}
 table.share_status tr>td{text-align:left;padding-left:12px}
 table.share_status tr>td+td{padding-left:0}
 table.share_status tbody tr{border-bottom:1px solid #0c0f0b}
@@ -66,7 +65,6 @@ table.share_status tbody tr.warn{color:#e68a00}
 table.share_status.fixed tr>td+td{min-width:39px;font-size:1.1rem;text-align:center;padding:0}
 table.share_status.table{margin-top:36px}
 table.share_status.table tr>td{width:50%}
-#####
 </style>
 <script>
 var disks = [];

--- a/source/file-integrity/FileIntegritySettings.page
+++ b/source/file-integrity/FileIntegritySettings.page
@@ -49,7 +49,20 @@ span.green-button{padding:1px 4px;margin-right:6px;border-radius:4px;border:1px 
 span.orange-button{padding:1px 4px;margin-right:6px;border-radius:4px;border:1px solid #FF9900;}
 span.red-button{padding:1px 4px;margin-right:6px;border-radius:4px;border:1px solid #CC0000;}
 .blue-text{color:#00529B;}
+####Unraid 7 Fix####
+table.share_status{white-space:nowrap;margin-top:12px}
+table.share_status thead tr:first-child td{font-size:1.2rem;letter-spacing:1px;text-transform:uppercase;color:#82857e;border-bottom:1px solid #60>
+table.share_status tr>td{text-align:left;padding-left:12px}
+table.share_status tr>td+td{padding-left:0}
+table.share_status tbody tr{border-bottom:1px solid #0c0f0b}
+table.share_status:not(.dashboard) tbody tr:hover td{background-color:rgba(255,255,255,0.05)}
+table.share_status tbody tr:last-child td{border-bottom:1px solid #606e7f}
+table.share_status tbody tr.alert{color:#f0000c}
+table.share_status tbody tr.warn{color:#e68a00}
 table.share_status.fixed tr>td+td{min-width:39px;font-size:1.1rem;text-align:center;padding:0}
+table.share_status.table{margin-top:36px}
+table.share_status.table tr>td{width:50%}
+#####
 </style>
 <script>
 function prepareWatch(form) {

--- a/source/file-integrity/FileIntegritySettings.page
+++ b/source/file-integrity/FileIntegritySettings.page
@@ -49,6 +49,7 @@ span.green-button{padding:1px 4px;margin-right:6px;border-radius:4px;border:1px 
 span.orange-button{padding:1px 4px;margin-right:6px;border-radius:4px;border:1px solid #FF9900;}
 span.red-button{padding:1px 4px;margin-right:6px;border-radius:4px;border:1px solid #CC0000;}
 .blue-text{color:#00529B;}
+table.share_status.fixed tr>td+td{min-width:39px;font-size:1.1rem;text-align:center;padding:0}
 </style>
 <script>
 function prepareWatch(form) {

--- a/source/file-integrity/FileIntegritySettings.page
+++ b/source/file-integrity/FileIntegritySettings.page
@@ -49,9 +49,8 @@ span.green-button{padding:1px 4px;margin-right:6px;border-radius:4px;border:1px 
 span.orange-button{padding:1px 4px;margin-right:6px;border-radius:4px;border:1px solid #FF9900;}
 span.red-button{padding:1px 4px;margin-right:6px;border-radius:4px;border:1px solid #CC0000;}
 .blue-text{color:#00529B;}
-####Unraid 7 Fix####
 table.share_status{white-space:nowrap;margin-top:12px}
-table.share_status thead tr:first-child td{font-size:1.2rem;letter-spacing:1px;text-transform:uppercase;color:#82857e;border-bottom:1px solid #60>
+table.share_status thead tr:first-child td{font-size:1.2rem;letter-spacing:1px;text-transform:uppercase;color:#82857e;border-bottom:1px solid #606e7f}
 table.share_status tr>td{text-align:left;padding-left:12px}
 table.share_status tr>td+td{padding-left:0}
 table.share_status tbody tr{border-bottom:1px solid #0c0f0b}
@@ -62,7 +61,6 @@ table.share_status tbody tr.warn{color:#e68a00}
 table.share_status.fixed tr>td+td{min-width:39px;font-size:1.1rem;text-align:center;padding:0}
 table.share_status.table{margin-top:36px}
 table.share_status.table tr>td{width:50%}
-#####
 </style>
 <script>
 function prepareWatch(form) {


### PR DESCRIPTION
The table class for "table.share_status.fixed" does no longer exist within V7, resulting in this

![Control](https://github.com/user-attachments/assets/0f33fc27-c0d3-4c69-a545-b6b114c3fd40)
![Settings](https://github.com/user-attachments/assets/9be19cbf-9aa8-4796-96fa-c26241ff680a)

Adding the class back

![Control 1](https://github.com/user-attachments/assets/e739fb00-3ef9-48f6-a955-253402f84e1d)
![Settings 1](https://github.com/user-attachments/assets/f8c0d352-c5df-4109-85c2-4b3f1e141057)

Would keep the visual coherency stable within v7