### PR TITLE
Fix System Stats for UnRaid 7 with only pool disks (no array)

### DIFF
--- a/source/system-stats/SystemDisks.page
+++ b/source/system-stats/SystemDisks.page
@@ -63,11 +63,13 @@ foreach ($disks as $disk) {
   }
 }
 
-$arrayused = $arraysize-$arrayfree;
-$totalpercent = 100-round(100*$parity/($arraysize+$parity));
-$totaldisk = 100-$totalpercent-$gap;
-$freepercent = $var['startMode']=='Normal' ? round(100*$arrayfree/$arraysize) : 100;
-$arraypercent = 100-$freepercent;
+if ($arraysize > 0) {
+  $arrayused = $arraysize-$arrayfree;
+  $totalpercent = 100-round(100*$parity/($arraysize+$parity));
+  $totaldisk = 100-$totalpercent-$gap;
+  $freepercent = $var['startMode']=='Normal' ? round(100*$arrayfree/$arraysize) : 100;
+  $arraypercent = 100-$freepercent;
+}
 
 if ($display['time']=="%R") {
   $hour = '%H:%M';
@@ -502,6 +504,7 @@ $(function() {
 <?endif;?>
 });
 </script>
+<?if ($arraysize>0):?>
 <div class="mybar whitebar leftbar" style="width:<?=$totalpercent?>%;"><span id="totalarray" class="mybar <?=bar_color($arraypercent)?> align-left" style="width:0"></span></div>
 <div class="mybar graybar rightbar" style="width:<?=$totaldisk?>%"></div>
 <div class="leftbar"><img src="<?="/plugins/$plugin/images"?>/array.png" class="left"><strong><?=my_scale($arraysize,$unit,-1,-1)." $unit"?></strong><br><small>_(Total Array Size)_</small></div>
@@ -516,6 +519,7 @@ $(function() {
 <?endif;?>
 <?if ($critical || $warning):?>
 <div class="rightbar"><span class="mybar greenbar inside"></span><strong>_(Below)_ <?=$warning?$display['warning']:$display['critical']?>%</strong><br><small>_(Normal Usage)_</small></div>
+<?endif;?>
 <?endif;?>
 <span id="sys" class="graph1"></span>
 <?if (!empty($cfg['stats']) && substr($cfg['stats'],0,5)!='Tasks'):?>

--- a/source/system-stats/SystemDisks.page
+++ b/source/system-stats/SystemDisks.page
@@ -35,7 +35,7 @@ $index  = $text=='left' ? 2 : 0;
 $parity = $arraysize = $arrayfree = 0;
 $series = $sizes = [];
 $gap    = 0.18;
-$height = 52;
+$height = 50;
 $y      = 2;
 $rows   = 0;
 
@@ -409,7 +409,7 @@ $(function() {
     credits:{enabled:false}
   });
   syschart = new Highcharts.Chart({
-    chart:{renderTo:'sys',events:{load:sys},type:'bar',height:<?=$rows*$height?>,width:getWidth(true),zoomType:null},
+    chart:{renderTo:'sys',events:{load:sys},type:'bar',height:<?=($rows*$height)+75?>,width:getWidth(true),zoomType:null},
     colors:[{linearGradient:{x1:0,y1:0,x2:0,y2:1},stops:[[0,'#941C00'],[1,'#DE1100']]},{linearGradient:{x1:0,y1:0,x2:0,y2:1},stops:[[0,'#CE7C10'],[1,'#F0B400']]},{linearGradient:{x1:0,y1:0,x2:0,y2:1},stops:[[0,'#17BF0B'],[1,'#127A05']]},{linearGradient:{x1:0,y1:0,x2:0,y2:1},stops:[[0,'#D9D9D9'],[1,'#949494']]}],
     plotOptions:{series:{stacking:'normal',animation:{duration:1000},pointPadding:0.2,groupPadding:0,
     dataLabels:{enabled:true,color:'#fff',align:'<?=$text?>',verticalAlign:'top',x:<?=$offset?>,y:<?=$y?>,style:{opacity:0},formatter:function(){if (this.series.index==<?=$index?>) return this.total+' %';}}}},


### PR DESCRIPTION
The System Statistics plugin is not working with the newly released UnRaid 7.0.0 when only Pool drives are used (i.e. no Array).

Navigating to the Stats tab just renders a blank page:
![image](https://github.com/user-attachments/assets/35de249e-cfa6-42ae-b8af-cc955277b769)

I've traced the issue down to a divide-by-zero error that causes the page to stop rendering.  This PR bypasses the array calculation logic and display if there isn't an array found.