### PR TITLE
Update autofan to make all drives available, not only HDDs

### DIFF
--- a/source/system-autofan/scripts/autofan
+++ b/source/system-autofan/scripts/autofan
@@ -200,7 +200,7 @@ function_get_highest_hd_temp() {
   [[ $(version $version) -ge $(version "6.8.9") ]] && HDD=1 || HDD=
   for DISK in "${HD[@]}"; do
     # Get disk state using sdspin (new) or hdparm (legacy)
-    [[ -n $HDD ]] && SLEEPING=`sdspin ${DISK}; echo $?` || SLEEPING=`hdparm -C ${DISK}|grep -c standby`
+    [[ -n $HDD ]] && SLEEPING=`hdparm -C ${DISK}|grep -c standby`
     if [[ $SLEEPING -eq 0 ]]; then
       if [[ $DISK == /dev/nvme[0-9] ]]; then
         CURRENT_TEMP=$(smartctl -n standby -A $DISK | awk '$1=="Temperature:" {print $2;exit}')


### PR DESCRIPTION
It seems like whenever all of my HDDs are spun down and only my NVME cache drives are still active, Autofan gets confused and thinks there is no active drives, and shuts down all selected fans.

Taken from: [Phoenix Down](https://forums.unraid.net/profile/106861-phoenix-down/) https://forums.unraid.net/topic/34889-dynamix-v6-plugins/page/144/
