### PR TITLE
Add support for passing user-defined options to file counting

### DIFF
--- a/source/cache-dirs/scripts/cache_dirs
+++ b/source/cache-dirs/scripts/cache_dirs
@@ -775,7 +775,7 @@ count_files() {
     for share_dir in $dir_list ; do
       dir_to_scan="$i/$share_dir"
       if [ -d "$dir_to_scan" ] ; then
-        local thisDirCount=$(find $dir_to_scan -type f $depth_arg | wc -l)
+        local thisDirCount=$(find $dir_to_scan $args $depth_arg | wc -l)
         totalCount=$((totalCount+thisDirCount))
       fi
     done


### PR DESCRIPTION
Ability to pass 'User defined options' to file counting

Merge request for the fix suggested here:

https://forums.unraid.net/topic/4351-cache_dirs-an-attempt-to-keep-directory-entries-in-ram-to-prevent-disk-spin-up/page/49/#findComment-1559589